### PR TITLE
remove song-level wacca info about song version

### DIFF
--- a/docs/user/stats/tachi.md
+++ b/docs/user/stats/tachi.md
@@ -371,8 +371,6 @@ Pros:
 
 Cons:
 
-- Significant favors good performance on charts released in
-  the most recent version of the game.
 - Uses wide cutoffs that don't reward AMs over SSS+.
 
 Although a better score statistic could be implemented, Rate


### PR DESCRIPTION
This con is not a property of a per-chart PB rating, it's a con of the profile-level rating.